### PR TITLE
Auth Callout - Fix Types

### DIFF
--- a/NATS.Jwt.Tests/Models/NatsAuthorizationRequestClaimsTests.cs
+++ b/NATS.Jwt.Tests/Models/NatsAuthorizationRequestClaimsTests.cs
@@ -38,7 +38,7 @@ public class NatsAuthorizationRequestClaimsTests
                 NatsClientInformation = new NatsClientInformation
                 {
                     Host = "client.example.com",
-                    Id = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    Id = 123,
                     User = "test_user",
                     Name = "Test Client",
                     Tags = new List<string> { "client_tag1", "client_tag2", },

--- a/NATS.Jwt/Models/NatsClientInformation.cs
+++ b/NATS.Jwt/Models/NatsClientInformation.cs
@@ -23,7 +23,7 @@ public record NatsClientInformation
     /// </summary>
     [JsonPropertyName("id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public long Id { get; set; }
+    public ulong Id { get; set; }
 
     /// <summary>
     /// Gets or sets the value representing the user property of the <see cref="NatsClientInformation"/> class.

--- a/NATS.Jwt/Models/NatsClientInformation.cs
+++ b/NATS.Jwt/Models/NatsClientInformation.cs
@@ -23,7 +23,7 @@ public record NatsClientInformation
     /// </summary>
     [JsonPropertyName("id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public string Id { get; set; }
+    public long Id { get; set; }
 
     /// <summary>
     /// Gets or sets the value representing the user property of the <see cref="NatsClientInformation"/> class.

--- a/NATS.Jwt/NatsJwt.cs
+++ b/NATS.Jwt/NatsJwt.cs
@@ -211,7 +211,7 @@ public class NatsJwt
     /// <returns>The encoded string representation of the authorization response claims.</returns>
     public string EncodeAuthorizationResponseClaims(NatsAuthorizationResponseClaims authorizationResponseClaims, KeyPair keyPair, DateTimeOffset? issuedAt = null)
     {
-        SetVersion(authorizationResponseClaims.AuthorizationResponse, AuthorizationRequestClaim);
+        SetVersion(authorizationResponseClaims.AuthorizationResponse, AuthorizationResponseClaim);
         return DoEncode(NatsJwtHeader, keyPair, authorizationResponseClaims, JsonContext.Default.NatsAuthorizationResponseClaims, issuedAt);
     }
 

--- a/NATS.Jwt/PublicAPI.Unshipped.txt
+++ b/NATS.Jwt/PublicAPI.Unshipped.txt
@@ -115,7 +115,7 @@ NATS.Jwt.Models.NatsAuthorizationResponseClaims.AuthorizationResponse.set -> voi
 NATS.Jwt.Models.NatsClientInformation
 NATS.Jwt.Models.NatsClientInformation.Host.get -> string!
 NATS.Jwt.Models.NatsClientInformation.Host.set -> void
-NATS.Jwt.Models.NatsClientInformation.Id.get -> long
+NATS.Jwt.Models.NatsClientInformation.Id.get -> ulong
 NATS.Jwt.Models.NatsClientInformation.Id.set -> void
 NATS.Jwt.Models.NatsClientInformation.Kind.get -> string!
 NATS.Jwt.Models.NatsClientInformation.Kind.set -> void

--- a/NATS.Jwt/PublicAPI.Unshipped.txt
+++ b/NATS.Jwt/PublicAPI.Unshipped.txt
@@ -115,7 +115,7 @@ NATS.Jwt.Models.NatsAuthorizationResponseClaims.AuthorizationResponse.set -> voi
 NATS.Jwt.Models.NatsClientInformation
 NATS.Jwt.Models.NatsClientInformation.Host.get -> string!
 NATS.Jwt.Models.NatsClientInformation.Host.set -> void
-NATS.Jwt.Models.NatsClientInformation.Id.get -> string!
+NATS.Jwt.Models.NatsClientInformation.Id.get -> long
 NATS.Jwt.Models.NatsClientInformation.Id.set -> void
 NATS.Jwt.Models.NatsClientInformation.Kind.get -> string!
 NATS.Jwt.Models.NatsClientInformation.Kind.set -> void


### PR DESCRIPTION
Two types in particular prevented me from properly responding to auth callout in non-operator mode. This PR contains the adjustments that enabled a successful response.