### PR TITLE
Scoped account signing keys

### DIFF
--- a/NATS.Jwt/Internal/NatsAccountSigningKeyConverter.cs
+++ b/NATS.Jwt/Internal/NatsAccountSigningKeyConverter.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) The NATS Authors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using NATS.Jwt.Models;
+
+namespace NATS.Jwt.Internal
+{
+    /// <summary>
+    /// .
+    /// </summary>
+    internal class NatsAccountSigningKeyConverter : JsonConverter<List<NatsAccountSigningKey>>
+    {
+        /// <summary>
+        /// Converts a JSON representation of SigningKeys to their correct type.
+        /// </summary>
+        /// <param name="reader">The Utf8JsonReader used to read the JSON data.</param>
+        /// <param name="typeToConvert">The type of the object to be converted.</param>
+        /// <param name="options">The JsonSerializerOptions to be used during serialization.</param>
+        /// <returns>A list of NatsAccountSigningKey.</returns>
+        /// <exception cref="JsonException">yeah, this isn't done yet.</exception>
+        public override List<NatsAccountSigningKey>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return default;
+            }
+            else if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("Expected Null or Array");
+            }
+
+            List<NatsAccountSigningKey> results = [];
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    return results;
+                }
+
+                if (reader.TokenType == JsonTokenType.String)
+                {
+                    string? simpleSigningKey = reader.GetString();
+                    if (simpleSigningKey != null)
+                    {
+                        results.Add(simpleSigningKey);
+                    }
+                }
+                else if (reader.TokenType == JsonTokenType.StartObject)
+                {
+                    NatsAccountScopedSigningKey? scopedSigningKey = JsonSerializer.Deserialize(ref reader, JsonContext.Default.NatsAccountScopedSigningKey);
+                    if (scopedSigningKey != null)
+                    {
+                        results.Add(scopedSigningKey);
+                    }
+                }
+                else
+                {
+                    throw new JsonException();
+                }
+            }
+
+            throw new JsonException();
+        }
+
+        /// <summary>
+        /// Writes the List of SigningKeys to its JSON representation.
+        /// </summary>
+        /// <param name="writer">The Utf8JsonWriter used to write the JSON data.</param>
+        /// <param name="value">The List of NatsAccountSigningKeys to be written.</param>
+        /// <param name="options">The JsonSerializerOptions to be used during serialization.</param>
+        public override void Write(Utf8JsonWriter writer, List<NatsAccountSigningKey> value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStartArray();
+
+                foreach (NatsAccountSigningKey sk in value)
+                {
+                    if (sk.GetType() == typeof(NatsAccountSigningKey))
+                    {
+                        writer.WriteStringValue((string)sk);
+                    }
+                    else if (sk.GetType() == typeof(NatsAccountScopedSigningKey))
+                    {
+                        JsonSerializer.Serialize(writer, (NatsAccountScopedSigningKey)sk, JsonContext.Default.NatsAccountScopedSigningKey);
+                    }
+                }
+
+                writer.WriteEndArray();
+            }
+        }
+    }
+}

--- a/NATS.Jwt/JsonContext.cs
+++ b/NATS.Jwt/JsonContext.cs
@@ -43,6 +43,8 @@ namespace NATS.Jwt;
 [JsonSerializable(typeof(NatsAuthorizationResponseClaims))]
 [JsonSerializable(typeof(NatsAuthorizationResponse))]
 [JsonSerializable(typeof(NatsGenericFieldsClaims))]
+[JsonSerializable(typeof(NatsAccountSigningKey))]
+[JsonSerializable(typeof(NatsAccountScopedSigningKey))]
 internal sealed partial class JsonContext : JsonSerializerContext
 {
 }

--- a/NATS.Jwt/Models/NatsAccount.cs
+++ b/NATS.Jwt/Models/NatsAccount.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using NATS.Jwt.Internal;
 
 namespace NATS.Jwt.Models;
 
@@ -49,7 +50,8 @@ public record NatsAccount : NatsGenericFields
     /// </value>
     [JsonPropertyName("signing_keys")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public List<string> SigningKeys { get; set; }
+    [JsonConverter(typeof(NatsAccountSigningKeyConverter))]
+    public List<NatsAccountSigningKey> SigningKeys { get; set; }
 
     /// <summary>
     /// Gets or sets the dictionary of revocations for the account.

--- a/NATS.Jwt/Models/NatsAccountScopedSigningKey.cs
+++ b/NATS.Jwt/Models/NatsAccountScopedSigningKey.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) The NATS Authors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace NATS.Jwt.Models
+{
+    /// <summary>
+    /// Represents an Account Scoped Signing Key.
+    /// </summary>
+    public record NatsAccountScopedSigningKey : NatsAccountSigningKey
+    {
+        /// <summary>
+        /// Gets or sets the kind of scoped key.
+        /// </summary>
+        [JsonPropertyName("kind")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string Kind { get; set; } = "user_scope";
+
+        /// <summary>
+        /// Gets or sets the Key, usually the public key.
+        /// </summary>
+        [JsonPropertyName("key")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets Role.
+        /// </summary>
+        [JsonPropertyName("role")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string Role { get; set; }
+
+        /// <summary>
+        /// Gets or sets the User Template to use.
+        /// </summary>
+        [JsonPropertyName("template")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public NatsUser Template { get; set; } = new();
+    }
+}

--- a/NATS.Jwt/Models/NatsAccountSigningKey.cs
+++ b/NATS.Jwt/Models/NatsAccountSigningKey.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) The NATS Authors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NATS.Jwt.Models
+{
+    /// <summary>
+    /// Represents an simple signing Key.
+    /// </summary>
+    public record NatsAccountSigningKey
+    {
+        private string _signingKey;
+
+        /// <summary>
+        /// An implicit operator to convert to a string.
+        /// </summary>
+        /// <param name="sk">A signing key.</param>
+        public static implicit operator string(NatsAccountSigningKey sk) => sk._signingKey;
+
+        /// <summary>
+        /// An implicit operator to convert from a string.
+        /// </summary>
+        /// <param name="value">A signing key.</param>
+        public static implicit operator NatsAccountSigningKey(string value)
+        {
+            return new NatsAccountSigningKey() { _signingKey = value };
+        }
+
+        /// <summary>
+        /// Returns the signing key as a string.
+        /// </summary>
+        /// <returns>The basic signing key.</returns>
+        public override string ToString()
+        {
+            return _signingKey;
+        }
+    }
+}

--- a/NATS.Jwt/Models/NatsGenericClaims.cs
+++ b/NATS.Jwt/Models/NatsGenericClaims.cs
@@ -18,5 +18,5 @@ public record NatsGenericClaims : JwtClaimsData
     [JsonPropertyName("nats")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyOrder(1)]
-    public Dictionary<string, JsonObject> Data { get; set; } = new();
+    public Dictionary<string, JsonNode> Data { get; set; } = new();
 }

--- a/NATS.Jwt/PublicAPI.Unshipped.txt
+++ b/NATS.Jwt/PublicAPI.Unshipped.txt
@@ -202,7 +202,7 @@ NATS.Jwt.Models.NatsExternalAuthorization.AuthUsers.set -> void
 NATS.Jwt.Models.NatsExternalAuthorization.XKey.get -> string!
 NATS.Jwt.Models.NatsExternalAuthorization.XKey.set -> void
 NATS.Jwt.Models.NatsGenericClaims
-NATS.Jwt.Models.NatsGenericClaims.Data.get -> System.Collections.Generic.Dictionary<string!, System.Text.Json.Nodes.JsonObject!>!
+NATS.Jwt.Models.NatsGenericClaims.Data.get -> System.Collections.Generic.Dictionary<string!, System.Text.Json.Nodes.JsonNode!>!
 NATS.Jwt.Models.NatsGenericClaims.Data.set -> void
 NATS.Jwt.Models.NatsGenericFields
 NATS.Jwt.Models.NatsGenericFields.Tags.get -> System.Collections.Generic.List<string!>!

--- a/NATS.Jwt/PublicAPI.Unshipped.txt
+++ b/NATS.Jwt/PublicAPI.Unshipped.txt
@@ -69,13 +69,23 @@ NATS.Jwt.Models.NatsAccount.Mappings.get -> System.Collections.Generic.Dictionar
 NATS.Jwt.Models.NatsAccount.Mappings.set -> void
 NATS.Jwt.Models.NatsAccount.Revocations.get -> System.Collections.Generic.Dictionary<string!, long>!
 NATS.Jwt.Models.NatsAccount.Revocations.set -> void
-NATS.Jwt.Models.NatsAccount.SigningKeys.get -> System.Collections.Generic.List<string!>!
+NATS.Jwt.Models.NatsAccount.SigningKeys.get -> System.Collections.Generic.List<NATS.Jwt.Models.NatsAccountSigningKey!>!
 NATS.Jwt.Models.NatsAccount.SigningKeys.set -> void
 NATS.Jwt.Models.NatsAccount.Trace.get -> NATS.Jwt.Models.NatsMsgTrace!
 NATS.Jwt.Models.NatsAccount.Trace.set -> void
 NATS.Jwt.Models.NatsAccountClaims
 NATS.Jwt.Models.NatsAccountClaims.Account.get -> NATS.Jwt.Models.NatsAccount!
 NATS.Jwt.Models.NatsAccountClaims.Account.set -> void
+NATS.Jwt.Models.NatsAccountScopedSigningKey
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Key.get -> string!
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Key.set -> void
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Kind.get -> string!
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Kind.set -> void
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Role.get -> string!
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Role.set -> void
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Template.get -> NATS.Jwt.Models.NatsUser!
+NATS.Jwt.Models.NatsAccountScopedSigningKey.Template.set -> void
+NATS.Jwt.Models.NatsAccountSigningKey
 NATS.Jwt.Models.NatsActivation
 NATS.Jwt.Models.NatsActivation.ImportSubject.get -> string!
 NATS.Jwt.Models.NatsActivation.ImportSubject.set -> void
@@ -393,6 +403,9 @@ NATS.Jwt.NatsJwt.NewOperatorClaims(string! subject) -> NATS.Jwt.Models.NatsOpera
 NATS.Jwt.NatsJwt.NewUserClaims(string! subject) -> NATS.Jwt.Models.NatsUserClaims!
 NATS.Jwt.NatsJwtException
 NATS.Jwt.NatsJwtException.NatsJwtException(string! message) -> void
+static readonly NATS.Jwt.NatsJwt.NatsJwtHeader -> NATS.Jwt.Models.JwtHeader!
 static NATS.Jwt.EncodingUtils.FromBase64UrlEncoded(string! encodedString) -> string!
 static NATS.Jwt.EncodingUtils.ToBase64UrlEncoded(byte[]! bytes) -> string!
-static readonly NATS.Jwt.NatsJwt.NatsJwtHeader -> NATS.Jwt.Models.JwtHeader!
+override NATS.Jwt.Models.NatsAccountSigningKey.ToString() -> string!
+static NATS.Jwt.Models.NatsAccountSigningKey.implicit operator NATS.Jwt.Models.NatsAccountSigningKey!(string! value) -> NATS.Jwt.Models.NatsAccountSigningKey!
+static NATS.Jwt.Models.NatsAccountSigningKey.implicit operator string!(NATS.Jwt.Models.NatsAccountSigningKey! sk) -> string!


### PR DESCRIPTION
Enhancement to add scoped account keys to the account.   

e.g.

```
            claimsAccount.Account.SigningKeys.Add(new NatsAccountScopedSigningKey
            {
                 Key = kpScopedAccountSigningKey.GetPublicKey(),
                 Role = "chat_user",
                 Template = new NatsUser()
                 {

                 }
            });

```

The list of signing keys still also supports strings via NatsAccountSigningKey which has implicit string operators.

Tested using $SYS.REQ.CLAIMS.UPDATE to push the new account, and then using the new SetScoped method from NatsUserClaims signing with the scoped account signing key.
