### PR TITLE
Fix datatype for NatsAccount.Mappings

### DIFF
--- a/src/NATS.Jwt/Models/NatsAccount.cs
+++ b/src/NATS.Jwt/Models/NatsAccount.cs
@@ -81,7 +81,7 @@ public record NatsAccount : NatsGenericFields
     /// </value>
     [JsonPropertyName("mappings")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public Dictionary<string, NatsWeightedMapping> Mappings { get; set; }
+    public Dictionary<string, List<NatsWeightedMapping>> Mappings { get; set; }
 
     /// <summary>
     /// Gets or sets the external authorization for the NATS account.

--- a/src/NATS.Jwt/PublicAPI.Unshipped.txt
+++ b/src/NATS.Jwt/PublicAPI.Unshipped.txt
@@ -65,7 +65,7 @@ NATS.Jwt.Models.NatsAccount.InfoUrl.get -> string!
 NATS.Jwt.Models.NatsAccount.InfoUrl.set -> void
 NATS.Jwt.Models.NatsAccount.Limits.get -> NATS.Jwt.Models.NatsOperatorLimits!
 NATS.Jwt.Models.NatsAccount.Limits.set -> void
-NATS.Jwt.Models.NatsAccount.Mappings.get -> System.Collections.Generic.Dictionary<string!, NATS.Jwt.Models.NatsWeightedMapping!>!
+NATS.Jwt.Models.NatsAccount.Mappings.get -> System.Collections.Generic.Dictionary<string!, System.Collections.Generic.List<NATS.Jwt.Models.NatsWeightedMapping!>!>!
 NATS.Jwt.Models.NatsAccount.Mappings.set -> void
 NATS.Jwt.Models.NatsAccount.Revocations.get -> System.Collections.Generic.Dictionary<string!, long>!
 NATS.Jwt.Models.NatsAccount.Revocations.set -> void

--- a/tests/NATS.Jwt.Tests/Models/NatsAccountClaimsTests.cs
+++ b/tests/NATS.Jwt.Tests/Models/NatsAccountClaimsTests.cs
@@ -92,11 +92,11 @@ public class NatsAccountClaimsTests
                     },
                 },
                 Mappings =
-                    new Dictionary<string, NatsWeightedMapping>
+                    new Dictionary<string, List<NatsWeightedMapping>>
                     {
                         {
                             "test",
-                            new NatsWeightedMapping { Subject = "test.>", Weight = 100, Cluster = "test_cluster" }
+                            new List<NatsWeightedMapping> {new NatsWeightedMapping { Subject = "test.>", Weight = 100, Cluster = "test_cluster" } }
                         },
                     },
                 DefaultPermissions =
@@ -188,9 +188,9 @@ public class NatsAccountClaimsTests
         Assert.Equal(claims.Account.Exports[0].AllowTrace, deserialized.Account.Exports[0].AllowTrace);
 
         Assert.Single(deserialized.Account.Mappings);
-        Assert.Equal(claims.Account.Mappings["test"].Subject, deserialized.Account.Mappings["test"].Subject);
-        Assert.Equal(claims.Account.Mappings["test"].Weight, deserialized.Account.Mappings["test"].Weight);
-        Assert.Equal(claims.Account.Mappings["test"].Cluster, deserialized.Account.Mappings["test"].Cluster);
+        Assert.Equal(claims.Account.Mappings["test"][0].Subject, deserialized.Account.Mappings["test"][0].Subject);
+        Assert.Equal(claims.Account.Mappings["test"][0].Weight, deserialized.Account.Mappings["test"][0].Weight);
+        Assert.Equal(claims.Account.Mappings["test"][0].Cluster, deserialized.Account.Mappings["test"][0].Cluster);
 
         Assert.Equal(claims.Account.DefaultPermissions.Pub.Allow, deserialized.Account.DefaultPermissions.Pub.Allow);
         Assert.Equal(claims.Account.DefaultPermissions.Pub.Deny, deserialized.Account.DefaultPermissions.Pub.Deny);


### PR DESCRIPTION
The datatype in the current preview version of NatsAccount.Mappings is incorrect and requires List Support.

Changed
`public Dictionary<string, NatsWeightedMapping> Mappings { get; set; }`

To
`public Dictionary<string, List<NatsWeightedMapping>> Mappings { get; set; }`
