### PR TITLE
Fix generic claims not signing

### DIFF
--- a/src/NATS.Jwt/NatsJwt.cs
+++ b/src/NATS.Jwt/NatsJwt.cs
@@ -475,7 +475,7 @@ public static class NatsJwt
 
         string issuer = keyPair.GetPublicKey();
         PrefixByte[] expectedPrefixes = c.ExpectedPrefixes();
-        if (!expectedPrefixes.Any(p => KeyPair.IsValidPublicKey(p, issuer.AsSpan())))
+        if (expectedPrefixes.Length > 0 && !expectedPrefixes.Any(p => KeyPair.IsValidPublicKey(p, issuer.AsSpan())))
         {
             throw new NatsJwtException($"Invalid signing key of '{keyPair.Prefix}': expected one of '{string.Join(",", expectedPrefixes)}'");
         }


### PR DESCRIPTION
When calling DoEncode for GenericClaims the expected prefixes length of 0 is stopping the signing and throwing an exception.  We can skip the check when expected prefixes length=0.