### PR TITLE
Bump NATS.NKeys to 1.0.1

### DIFF
--- a/src/NATS.Jwt/NATS.Jwt.csproj
+++ b/src/NATS.Jwt/NATS.Jwt.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NATS.NKeys" Version="1.0.0" />
+    <PackageReference Include="NATS.NKeys" Version="1.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" ExcludeAssets="Compile" PrivateAssets="All"/>
   </ItemGroup>
 


### PR DESCRIPTION
Bumps the NATS.NKeys dependency from 1.0.0 to 1.0.1. https://github.com/nats-io/nkeys.net/pull/27