### PR TITLE
Add concurrency to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   update-docs:
     name: docfx


### PR DESCRIPTION
Adds a `pages` concurrency group to `.github/workflows/docs.yml` so two overlapping pushes to `main` can't race on the same Pages deployment. Matches GitHub's starter Pages workflow.