### PR TITLE
Add permissions block to format and test workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,6 +3,9 @@
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   dotnet:
     name: dotnet


### PR DESCRIPTION
Restricts the default GITHUB_TOKEN permissions to contents: read on the format and test workflows, matching the pattern already used in the other workflows. Fixes two open code-scanning alerts (actions/missing-workflow-permissions).